### PR TITLE
Update config.yml.example

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -14,6 +14,7 @@ nginx:
     listen *:443 ssl;
     ssl_certificate     /path/to/cert/dir/server.crt;
     ssl_certificate_key /path/to/cert/dir/server.key;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   config_template: |
     #{upstream}
     server {


### PR DESCRIPTION
Due to trouble with SSLv3, supported ssl ciphers need to be listed explicit.

I suggest add to file `config.yml.example` following line

```
ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
```

More info about nginx security: https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html

See pull request 
